### PR TITLE
readme: fix unfinished code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Existing configuration file are:
 ./tools/confs/6windgate-4.19.yml
 ./tools/confs/turbo-router-1.6.yml
 ./tools/confs/6windgate-next.yml
+```
 
 Configuration files can be stored anywhere but only configuration file present in the [tools/confs](./tools/confs) directory are listed
 


### PR DESCRIPTION
After displaying existing configuration file, the literal block is not
terminated. The rest of the README is thus parsed as literal.

Signed-off-by: Gaetan Rivet <gaetan.rivet@6wind.com>